### PR TITLE
Update CommandBusTest.php

### DIFF
--- a/tests/Behaviour/CommandBusTest.php
+++ b/tests/Behaviour/CommandBusTest.php
@@ -25,7 +25,7 @@ class CommandBusTest extends TestCase
      */
     private $outputInterface;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->app =  new CommandApplication();
         $this->input = \Mockery::mock(InputInterface::class);


### PR DESCRIPTION
PHP Fatal error:  Declaration of Bruli\EventBusBundleTests\Behaviour\CommandBusTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void